### PR TITLE
Move Installation instructions up in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ SVG is useful for device-independent resolution, but can often be a pain because
 
 If your SVG assets look great on your computer and messed up on everyone else's, it's because the fonts aren't embedded properly in the file.
 
+### Installation
+
+Download the executable appropriate for your operating system on the [releases page](https://github.com/BTBurke/svg-embed-font/releases).
+
+You can also clone the project repository and compile the source code locally if you have the [Go compiler](https://golang.org/) available.
+
 ### Usage
 
 ```
@@ -47,10 +53,6 @@ The font file is Base64 encoded and included as a stylesheet asset directly in t
 	]]>
 </style>
 ```
-
-### Installation
-
-Download the release appropriate for your operating system on the [releases page](https://github.com/BTBurke/svg-embed-font/releases).
 
 ### License
 


### PR DESCRIPTION
In particular, the Installation instructions now appear before the Usage instructions.
From a logical sequence perspective, that order of sections better matches the typical user experience, as one must download/install a tool before it can be used.

This change also mentions the possibility of compiling the source code, which some users may prefer. (This particular point was raised in #1.)