### PR TITLE
Find font by url

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	svgEmbedFileName := strings.Replace(svgFile, ".", ".embed.", 1)
+	svgEmbedFileName := strings.Replace(svgFile, ".svg", ".embed.svg", 1)
 	if err := ioutil.WriteFile(svgEmbedFileName, svgEmbed, 0644); err != nil {
 		fmt.Printf("Error: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
This is a quick hack so that I can make some slides for a meetup (https://github.com/alsuren/mijia-homie/pull/168), as a stop-gap, until https://github.com/excalidraw/excalidraw/issues/1972 is implemented upstream.

This is probably not idiomatic Go. I'm happy to change anything that smells fishy.