### PR TITLE
Add link to Dockerhub container

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The font file is Base64 encoded and included as a stylesheet asset directly in t
 
 ### Installation
 
-Download the release appropriate for your operating system on the [releases page](https://github.com/BTBurke/svg-embed-font/releases).
+Download the release appropriate for your operating system on the [releases page](https://github.com/BTBurke/svg-embed-font/releases), or use the [container on Dockerhub](https://hub.docker.com/repository/docker/ningyuan/svg-embed-font/).
 
 ### License
 


### PR DESCRIPTION
```
ning@bluecoral ~/repos/svg-embed-font$ docker run --rm ningyuan/svg-embed-font:0.0.1

Usage:
svg-font-embed input.svg [font1.ttf font2.ttf]

Required Arguments:
input.svg - The SVG file to embed fonts within

Optional Arguments:
font.ttf - Specify one or more font files to embed within the SVG document.  Fonts do not have to be specified unless it is not obvious which file matches the fonts in the SVG file.

If no fonts are specified, the current directory and all subdirectories will be walked to look for a matching font file.  A match is defined as a font file which has the font-family name in its file name.  When multiple font files exists that would match (such as when the font comes in different weights), an error will be thrown unless you specify which font file to use on the command line.
```